### PR TITLE
Feature/Add track tile models

### DIFF
--- a/src/track/helpers/index.js
+++ b/src/track/helpers/index.js
@@ -1,0 +1,28 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export {
+    TILE_DIRECTION_RIGHT,
+    TILE_DIRECTION_LEFT,
+    DEFAULT_TILE_TYPE,
+    STRAIGHT_TILE_TYPE,
+    CURVED_TILE_TYPE,
+    CURVED_TILE_ENLARGED_TYPE,
+    isDirectionValid,
+    isTypeValid
+} from './tiles.js';

--- a/src/track/helpers/test/tiles.spec.js
+++ b/src/track/helpers/test/tiles.spec.js
@@ -1,0 +1,59 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+    CURVED_TILE_ENLARGED_TYPE,
+    CURVED_TILE_TYPE,
+    DEFAULT_TILE_TYPE,
+    isDirectionValid,
+    isTypeValid,
+    STRAIGHT_TILE_TYPE,
+    TILE_DIRECTION_LEFT,
+    TILE_DIRECTION_RIGHT
+} from '../tiles.js';
+
+describe('isDirectionValid', () => {
+    it('is a function', () => {
+        expect(isDirectionValid).toEqual(expect.any(Function));
+    });
+
+    it.each([TILE_DIRECTION_RIGHT, TILE_DIRECTION_LEFT])('tells the direction "%s" is valid', direction => {
+        expect(isDirectionValid(direction)).toBeTruthy();
+    });
+
+    it.each([-1, 0, 1, 2])('tells the direction "%s" is not valid', direction => {
+        expect(isDirectionValid(direction)).toBeFalsy();
+    });
+});
+
+describe('isTypeValid', () => {
+    it('is a function', () => {
+        expect(isTypeValid).toEqual(expect.any(Function));
+    });
+
+    it.each([STRAIGHT_TILE_TYPE, CURVED_TILE_TYPE, CURVED_TILE_ENLARGED_TYPE])(
+        'tells the type "%s" is valid',
+        direction => {
+            expect(isTypeValid(direction)).toBeTruthy();
+        }
+    );
+
+    it.each([DEFAULT_TILE_TYPE, 'left', 'right'])('tells the type "%s" is not valid', direction => {
+        expect(isTypeValid(direction)).toBeFalsy();
+    });
+});

--- a/src/track/helpers/tiles.js
+++ b/src/track/helpers/tiles.js
@@ -1,0 +1,79 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tile oriented to the right.
+ * @type {string}
+ */
+export const TILE_DIRECTION_RIGHT = 'right';
+
+/**
+ * Tile oriented to the left.
+ * @type {string}
+ */
+export const TILE_DIRECTION_LEFT = 'left';
+
+/**
+ * Type for a default tile.
+ * @type {string}
+ */
+export const DEFAULT_TILE_TYPE = 'tile';
+
+/**
+ * Type for a straight tile.
+ * @type {string}
+ */
+export const STRAIGHT_TILE_TYPE = 'straight-tile';
+
+/**
+ * Type for a curved tile.
+ * @type {string}
+ */
+export const CURVED_TILE_TYPE = 'curved-tile';
+
+/**
+ * Type for an enlarged curve tile.
+ * @type {string}
+ */
+export const CURVED_TILE_ENLARGED_TYPE = 'curved-tile-enlarged';
+
+/**
+ * @type {string[]} - The list of allowed tile directions.
+ * @private
+ */
+const allowedDirection = [TILE_DIRECTION_RIGHT, TILE_DIRECTION_LEFT];
+
+/**
+ * Checks if a given direction is valid for a tile.
+ * @param {*} direction - The direction to check.
+ * @returns {boolean} - Returns `true` if the direction is valid.
+ */
+export const isDirectionValid = direction => allowedDirection.includes(direction);
+
+/**
+ * @type {string[]} - The list of allowed tile types.
+ * @private
+ */
+const allowedTypes = [STRAIGHT_TILE_TYPE, CURVED_TILE_TYPE, CURVED_TILE_ENLARGED_TYPE];
+
+/**
+ * Checks if a given type is valid for a tile.
+ * @param {*} type - The type to check.
+ * @returns {boolean} - Returns `true` if the type is valid.
+ */
+export const isTypeValid = type => allowedTypes.includes(type);

--- a/src/track/models/CurvedTileEnlargedModel.js
+++ b/src/track/models/CurvedTileEnlargedModel.js
@@ -1,0 +1,165 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CURVED_TILE_ENLARGED_TYPE } from '../helpers';
+import { TileModel } from './TileModel.js';
+import { Vector2D } from '../../core/models';
+
+/**
+ * Represents a track tile for an enlarged curve.
+ */
+export class CurvedTileEnlargedModel extends TileModel {
+    /**
+     * Sets the size factor relative to a track section.
+     * 1 means the tile fits 1 tile section in each direction.
+     * @param {number} ratio - The size factor relative to a track section.
+     * @returns {CurvedTileEnlargedModel} - Chains the instance.
+     */
+    setRatio(ratio) {
+        this.ratio = Math.max(1, Math.floor(Math.abs(ratio)));
+        return this;
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the left.
+     * @returns {number}
+     */
+    getDirectionAngleLeft() {
+        return 90;
+    }
+
+    /**
+     * Computes the angle of the curve with respect to the ratio.
+     * @returns {number}
+     */
+    getCurveAngle() {
+        return 90;
+    }
+
+    /**
+     * Computes the length of the curve side if any.
+     * @returns {number}
+     */
+    getCurveSide() {
+        return this.length / 2;
+    }
+
+    /**
+     * Computes the number of barrier chunks on each side with respect to the ratio.
+     * @returns {number}
+     */
+    getSideBarrierChunks() {
+        return (this.specs.barrierChunks * this.ratio) / 2;
+    }
+
+    /**
+     * Computes the number of barrier chunks for the inner curve with respect to the ratio.
+     * @returns {number}
+     */
+    getInnerBarrierChunks() {
+        if (this.ratio <= 1) {
+            return this.specs.barrierChunks / 2;
+        }
+        return this.specs.barrierChunks * this.ratio;
+    }
+
+    /**
+     * Computes the number of barrier chunks for an outer curve with respect to the ratio.
+     * @returns {number}
+     */
+    getOuterBarrierChunks() {
+        return (this.specs.barrierChunks / 2) * this.ratio;
+    }
+
+    /**
+     * Computes the coordinates of the center point.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getCenterCoord(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+        const center = start.addScalarY(this.specs.length * (this.ratio - 0.5));
+
+        return center.rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the right.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordRight(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        const radius = this.getInnerRadius() + this.specs.width / 2;
+        const curveAngle = this.getCurveAngle();
+        const center = start.subScalarX(radius);
+
+        return Vector2D.polar(radius, curveAngle, center).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the left.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordLeft(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        const radius = this.getInnerRadius() + this.specs.width / 2;
+        const curveAngle = this.getCurveAngle();
+        const center = start.addScalarX(radius);
+
+        return Vector2D.polar(radius, curveAngle, center).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the right.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleRight(angle = 0) {
+        return angle + 90;
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the left.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleLeft(angle = 0) {
+        return angle - 90;
+    }
+}
+
+/**
+ * The type of tile.
+ * @constant {string} CurvedTileEnlargedModel.TYPE
+ */
+Object.defineProperty(CurvedTileEnlargedModel, 'TYPE', {
+    value: CURVED_TILE_ENLARGED_TYPE,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});

--- a/src/track/models/CurvedTileModel.js
+++ b/src/track/models/CurvedTileModel.js
@@ -1,0 +1,149 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CURVED_TILE_TYPE } from '../helpers';
+import { TileModel } from './TileModel.js';
+import { Vector2D } from '../../core/models';
+
+/**
+ * Represents a track tile for a curve.
+ */
+export class CurvedTileModel extends TileModel {
+    /**
+     * The actual length of the tile with respect to the ratio.
+     * @type {number}
+     */
+    get length() {
+        return this.specs.length;
+    }
+
+    /**
+     * The actual width of the tile with respect to the ratio.
+     * @type {number}
+     */
+    get width() {
+        return this.specs.width;
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the left.
+     * @returns {number}
+     */
+    getDirectionAngleLeft() {
+        return 90 + (90 / this.ratio) * (Math.max(1, this.ratio) - 1);
+    }
+
+    /**
+     * Computes the angle of the curve with respect to the ratio.
+     * @returns {number}
+     */
+    getCurveAngle() {
+        if (this.ratio < 1) {
+            return 90 * this.ratio;
+        }
+
+        return 90 / this.ratio;
+    }
+
+    /**
+     * Computes the coordinates of the center point.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getCenterCoord(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        const curveAngle = this.getCurveAngle();
+        const curveCenter = this.getCurveCenter().add(start);
+        const radius = this.getInnerRadius() + this.specs.width / 2;
+
+        const p1 = Vector2D.polar(radius, 0, curveCenter);
+        const p2 = p1.addScalarY(10);
+        const p3 = Vector2D.polar(radius, curveAngle, curveCenter);
+        const p4 = p3.add(Vector2D.polar(10, curveAngle + 90));
+
+        const center = Vector2D.intersect(p1, p2, p3, p4);
+
+        return center.rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the right.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordRight(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        const radius = this.getInnerRadius() + this.specs.width / 2;
+        const curveAngle = this.getCurveAngle();
+        const center = start.subScalarX(radius);
+
+        return Vector2D.polar(radius, curveAngle, center).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the left.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordLeft(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        const radius = this.getInnerRadius() + this.specs.width / 2;
+        const curveAngle = 180 - this.getCurveAngle();
+        const center = start.addScalarX(radius);
+
+        return Vector2D.polar(radius, curveAngle, center).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the right.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleRight(angle = 0) {
+        return angle + this.getCurveAngle();
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the left.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleLeft(angle = 0) {
+        return angle - this.getCurveAngle();
+    }
+}
+
+/**
+ * The type of tile.
+ * @constant {string} CurvedTileModel.TYPE
+ */
+Object.defineProperty(CurvedTileModel, 'TYPE', {
+    value: CURVED_TILE_TYPE,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});

--- a/src/track/models/StraightTileModel.js
+++ b/src/track/models/StraightTileModel.js
@@ -1,0 +1,52 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { STRAIGHT_TILE_TYPE } from '../helpers';
+import { TileModel } from './TileModel.js';
+
+/**
+ * Represents a straight track tile.
+ */
+export class StraightTileModel extends TileModel {
+    /**
+     * The actual width of the tile with respect to the ratio.
+     * @type {number}
+     */
+    get width() {
+        return this.specs.width;
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the left.
+     * @returns {number}
+     */
+    getDirectionAngleLeft() {
+        return 180;
+    }
+}
+
+/**
+ * The type of tile.
+ * @constant {string} StraightTileModel.TYPE
+ */
+Object.defineProperty(StraightTileModel, 'TYPE', {
+    value: STRAIGHT_TILE_TYPE,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});

--- a/src/track/models/TileModel.js
+++ b/src/track/models/TileModel.js
@@ -1,0 +1,351 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isDirectionValid, DEFAULT_TILE_TYPE, TILE_DIRECTION_LEFT, TILE_DIRECTION_RIGHT } from '../helpers';
+import { TileSpecifications } from './TileSpecifications.js';
+import { Vector2D } from '../../core/models';
+
+/**
+ * Represents a track tile.
+ */
+export class TileModel {
+    /**
+     * Represents a tile with the given size constraints.
+     * @param {TileSpecifications} specs - The specifications for the tiles.
+     * @param {string} direction - The direction of the tile.
+     * @param {number} ratio - The size factor relative to a track section. 1 means the tile fits 1 tile section in each direction.
+     * @throws {TypeError} - If the given specifications object is not valid.
+     * @throws {TypeError} - If the given direction is not valid.
+     */
+    constructor(specs, direction = TILE_DIRECTION_RIGHT, ratio = 1) {
+        this.setSpecs(specs);
+        this.setDirection(direction);
+        this.setRatio(ratio);
+    }
+
+    /**
+     * The type of tile.
+     * @type {string}
+     */
+    get type() {
+        // @ts-expect-error
+        return this.constructor.TYPE;
+    }
+
+    /**
+     * The identifier for the model.
+     * @type {string}
+     */
+    get id() {
+        return `${this.type}-${this.ratio}`;
+    }
+
+    /**
+     * The actual length of the tile with respect to the ratio.
+     * @type {number}
+     */
+    get length() {
+        return this.specs.length * this.ratio;
+    }
+
+    /**
+     * The actual width of the tile with respect to the ratio.
+     * @type {number}
+     */
+    get width() {
+        return this.specs.width * this.ratio;
+    }
+
+    /**
+     * Sets the specifications for the tiles.
+     * @param {TileSpecifications} specs - The specifications for the tiles.
+     * @returns {TileModel} - Chains the instance.
+     * @throws {TypeError} - If the given specifications object is not valid.
+     */
+    setSpecs(specs) {
+        if (!specs || !(specs instanceof TileSpecifications)) {
+            throw new TypeError('A valid specifications object is needed!');
+        }
+
+        this.specs = specs;
+
+        return this;
+    }
+
+    /**
+     * Sets the direction of the tile.
+     * It can be either TILE_DIRECTION_RIGHT or TILE_DIRECTION_LEFT.
+     * @param {string} direction - The direction of the tile.
+     * @returns {TileModel} - Chains the instance.
+     * @throws {TypeError} - If the given direction is not valid.
+     */
+    setDirection(direction) {
+        if (!isDirectionValid(direction)) {
+            throw new TypeError('A valid direction is needed!');
+        }
+
+        this.direction = direction;
+
+        return this;
+    }
+
+    /**
+     * Sets the size factor relative to a track section.
+     * 1 means the tile fits 1 tile section in each direction.
+     * @param {number} ratio - The size factor relative to a track section.
+     * @returns {TileModel} - Chains the instance.
+     */
+    setRatio(ratio) {
+        this.ratio = Math.abs(ratio || 1);
+
+        return this;
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the expected direction.
+     * @returns {number}
+     */
+    getDirectionAngle() {
+        switch (this.direction) {
+            case TILE_DIRECTION_RIGHT:
+                return this.getDirectionAngleRight();
+
+            case TILE_DIRECTION_LEFT:
+                return this.getDirectionAngleLeft();
+        }
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the right.
+     * @returns {number}
+     */
+    getDirectionAngleRight() {
+        return 0;
+    }
+
+    /**
+     * Computes the angle for rotating the tile to the left.
+     * @returns {number}
+     */
+    getDirectionAngleLeft() {
+        return 0;
+    }
+
+    /**
+     * Computes the angle of the curve with respect to the ratio.
+     * @returns {number}
+     */
+    getCurveAngle() {
+        return 0;
+    }
+
+    /**
+     * Computes the length of the curve side if any.
+     * @returns {number}
+     */
+    getCurveSide() {
+        return 0;
+    }
+
+    /**
+     * Computes the coordinates of the curve center with respect to the tile position.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @returns {Vector2D}
+     */
+    getCurveCenter(x = 0, y = 0) {
+        const offset = this.specs.padding - this.getInnerRadius() - this.specs.length / 2;
+
+        return new Vector2D(x + offset, y);
+    }
+
+    /**
+     * Computes the inner radius of the curve with respect to the ratio.
+     * @returns {number}
+     */
+    getInnerRadius() {
+        const ratio = Math.max(1, this.ratio) - 1;
+        return this.specs.length * ratio + this.specs.padding;
+    }
+
+    /**
+     * Computes the outer radius of the curve with respect to the ratio.
+     * @returns {number}
+     */
+    getOuterRadius() {
+        return this.specs.width + this.getInnerRadius() - this.getCurveSide();
+    }
+
+    /**
+     * Computes the number of barrier chunks on each side with respect to the ratio.
+     * @returns {number}
+     */
+    getSideBarrierChunks() {
+        return this.specs.barrierChunks * this.ratio;
+    }
+
+    /**
+     * Computes the number of barrier chunks for the inner curve with respect to the ratio.
+     * @returns {number}
+     */
+    getInnerBarrierChunks() {
+        if (this.ratio < 1) {
+            return 1;
+        }
+
+        if (this.ratio < 2) {
+            return this.specs.barrierChunks / 2;
+        }
+
+        return this.specs.barrierChunks;
+    }
+
+    /**
+     * Computes the number of barrier chunks for the outer curve with respect to the ratio.
+     * @returns {number}
+     */
+    getOuterBarrierChunks() {
+        if (this.ratio < 1) {
+            return this.specs.barrierChunks / 2;
+        }
+
+        return this.specs.barrierChunks;
+    }
+
+    /**
+     * Computes the coordinates of the center point.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getCenterCoord(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        return start.addScalarY(this.length / 2).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point with respect to the tile direction.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoord(x = 0, y = 0, angle = 0) {
+        switch (this.direction) {
+            case TILE_DIRECTION_RIGHT:
+                return this.getOutputCoordRight(x, y, angle);
+
+            case TILE_DIRECTION_LEFT:
+                return this.getOutputCoordLeft(x, y, angle);
+        }
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the right.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordRight(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        return start.addScalarY(this.length).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the coordinates of the output point when the tile is oriented to the left.
+     * @param {number} x - The X-coordinate of the tile.
+     * @param {number} y - The Y-coordinate of the tile.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {Vector2D}
+     */
+    getOutputCoordLeft(x = 0, y = 0, angle = 0) {
+        const start = new Vector2D(x, y);
+
+        return start.addScalarY(this.length).rotateAround(angle, start);
+    }
+
+    /**
+     * Computes the angle of the output point with respect to the tile direction.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngle(angle = 0) {
+        switch (this.direction) {
+            case TILE_DIRECTION_RIGHT:
+                return this.getOutputAngleRight(angle);
+
+            case TILE_DIRECTION_LEFT:
+                return this.getOutputAngleLeft(angle);
+        }
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the right.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleRight(angle = 0) {
+        return angle;
+    }
+
+    /**
+     * Computes the angle of the output point when the tile is oriented to the left.
+     * @param {number} angle - The rotation angle of the tile.
+     * @returns {number}
+     */
+    getOutputAngleLeft(angle = 0) {
+        return angle;
+    }
+}
+
+/**
+ * The type of tile.
+ * @constant {string} TileModel.TYPE
+ */
+Object.defineProperty(TileModel, 'TYPE', {
+    value: DEFAULT_TILE_TYPE,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
+
+/**
+ * Tile oriented to the right.
+ * @constant {string} TileModel.DIRECTION_RIGHT
+ */
+Object.defineProperty(TileModel, 'DIRECTION_RIGHT', {
+    value: TILE_DIRECTION_RIGHT,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});
+
+/**
+ * Tile oriented to the left.
+ * @constant {string} TileModel.DIRECTION_LEFT
+ */
+Object.defineProperty(TileModel, 'DIRECTION_LEFT', {
+    value: TILE_DIRECTION_LEFT,
+    writable: false,
+    enumerable: true,
+    configurable: true
+});

--- a/src/track/models/TileSpecifications.js
+++ b/src/track/models/TileSpecifications.js
@@ -1,0 +1,100 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Gives the specifications for the track tiles with respect to the initial constraints.
+ */
+export class TileSpecifications {
+    /**
+     * Defines the specifications for the track tiles from the given constraints.
+     * @param {number} laneWidth - The width of the track lane (the distance between the barriers).
+     * @param {number} barrierWidth - The width of the barriers.
+     * @param {number} barrierChunks - The number of barrier chunks per tile.
+     */
+    constructor(laneWidth, barrierWidth, barrierChunks) {
+        this.setLaneWidth(laneWidth);
+        this.setBarrierWidth(barrierWidth);
+        this.setBarrierChunks(barrierChunks);
+    }
+
+    /**
+     * The length of a tile with respect to the initial constraints.
+     * @type {number}
+     */
+    get length() {
+        return this.laneWidth * 1.25 + this.barrierWidth * 2;
+    }
+
+    /**
+     * The width of a tile with respect to the initial constraints.
+     * @type {number}
+     */
+    get width() {
+        return this.laneWidth + this.barrierWidth * 2;
+    }
+
+    /**
+     * The length of a barrier chunk with respect to the initial constraints.
+     * @type {number}
+     */
+    get barrierLength() {
+        return this.length / this.barrierChunks;
+    }
+
+    /**
+     * The padding around the width of the tile to align with its length.
+     * Note: tiles must fit in a square so that they can be flipped and rotated indifferently.
+     * @type {number}
+     */
+    get padding() {
+        return this.laneWidth / 8;
+    }
+
+    /**
+     * Sets the width of the track lane (the distance between the barriers).
+     * @param {number} laneWidth - The width of the track lane.
+     * @returns {TileSpecifications} - Chains the instance.
+     */
+    setLaneWidth(laneWidth) {
+        this.laneWidth = Math.abs(laneWidth);
+
+        return this;
+    }
+
+    /**
+     * Sets the width of the barriers.
+     * @param {number} barrierWidth - The width of the barriers.
+     * @returns {TileSpecifications} - Chains the instance.
+     */
+    setBarrierWidth(barrierWidth) {
+        this.barrierWidth = Math.abs(barrierWidth);
+
+        return this;
+    }
+
+    /**
+     * Sets the number of barrier chunks per tile.
+     * @param {number} barrierChunks - The number of barrier chunks per tile.
+     * @returns {TileSpecifications} - Chains the instance.
+     */
+    setBarrierChunks(barrierChunks) {
+        this.barrierChunks = Math.abs(Math.round(barrierChunks) || 1);
+
+        return this;
+    }
+}

--- a/src/track/models/index.js
+++ b/src/track/models/index.js
@@ -16,4 +16,5 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+export { TileModel } from './TileModel.js';
 export { TileSpecifications } from './TileSpecifications.js';

--- a/src/track/models/index.js
+++ b/src/track/models/index.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+export { CurvedTileModel } from './CurvedTileModel.js';
 export { StraightTileModel } from './StraightTileModel.js';
 export { TileModel } from './TileModel.js';
 export { TileSpecifications } from './TileSpecifications.js';

--- a/src/track/models/index.js
+++ b/src/track/models/index.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+export { CurvedTileEnlargedModel } from './CurvedTileEnlargedModel.js';
 export { CurvedTileModel } from './CurvedTileModel.js';
 export { StraightTileModel } from './StraightTileModel.js';
 export { TileModel } from './TileModel.js';

--- a/src/track/models/index.js
+++ b/src/track/models/index.js
@@ -1,0 +1,19 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { TileSpecifications } from './TileSpecifications.js';

--- a/src/track/models/index.js
+++ b/src/track/models/index.js
@@ -16,5 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+export { StraightTileModel } from './StraightTileModel.js';
 export { TileModel } from './TileModel.js';
 export { TileSpecifications } from './TileSpecifications.js';

--- a/src/track/models/test/CurvedTileEnlargedModel.spec.js
+++ b/src/track/models/test/CurvedTileEnlargedModel.spec.js
@@ -1,0 +1,255 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CurvedTileEnlargedModel } from '../CurvedTileEnlargedModel.js';
+import { TileSpecifications } from '../TileSpecifications.js';
+
+const tileX = 100;
+const tileY = 100;
+const tileRatios = [0.5, 1, 2, 3, 4];
+const laneWidth = 80;
+const tileLength = 110;
+const tileWidth = 90;
+const barrierWidth = 5;
+const barrierChunks = 4;
+const specs = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+describe('CurvedTileEnlargedModel', () => {
+    it('is a class', () => {
+        expect(CurvedTileEnlargedModel).toEqual(expect.any(Function));
+    });
+
+    describe('throws error', () => {
+        it('when trying to create an instance with an invalid specifications object', () => {
+            // @ts-expect-error
+            expect(() => new CurvedTileEnlargedModel({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to create an instance with an invalid direction', () => {
+            expect(() => new CurvedTileEnlargedModel(specs, '')).toThrow('A valid direction is needed!');
+        });
+
+        it('when trying to set an invalid specifications object', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+            // @ts-expect-error
+            expect(() => tile.setSpecs({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to set an invalid direction', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+            expect(() => tile.setDirection('')).toThrow('A valid direction is needed!');
+        });
+    });
+
+    describe('can build a tile', () => {
+        it('with the given size', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+
+            expect(tile).toBeInstanceOf(CurvedTileEnlargedModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileEnlargedModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileEnlargedModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it('with the given size and direction', () => {
+            const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_LEFT);
+
+            expect(tile).toBeInstanceOf(CurvedTileEnlargedModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileEnlargedModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileEnlargedModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it.each(tileRatios)('with the given size and a ratio of %s', ratio => {
+            const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_LEFT, ratio);
+            const sizeRatio = Math.max(1, ratio);
+
+            expect(tile).toBeInstanceOf(CurvedTileEnlargedModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileEnlargedModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileEnlargedModel.TYPE}-${sizeRatio}`);
+            expect(tile.length).toBe(tileLength * sizeRatio);
+            expect(tile.width).toBe(tileWidth * sizeRatio);
+        });
+    });
+
+    describe('can set', () => {
+        it('the specifications of the tile', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+            const newSpecs = new TileSpecifications(10, 1, 2);
+
+            expect(tile.specs).toBeInstanceOf(TileSpecifications);
+            expect(tile.specs).not.toBe(newSpecs);
+            expect(tile.setSpecs(newSpecs)).toBe(tile);
+            expect(tile.specs).toBe(newSpecs);
+        });
+
+        it('the direction of the tile', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+
+            expect(tile.direction).toBe(CurvedTileEnlargedModel.DIRECTION_RIGHT);
+            expect(tile.setDirection(CurvedTileEnlargedModel.DIRECTION_LEFT)).toBe(tile);
+            expect(tile.direction).toBe(CurvedTileEnlargedModel.DIRECTION_LEFT);
+        });
+
+        it('the size ratio', () => {
+            const tile = new CurvedTileEnlargedModel(specs);
+            expect(tile.setRatio(1)).toBe(tile);
+            expect(tile.ratio).toBe(1);
+            expect(tile.setRatio(-1).ratio).toBe(1);
+            expect(tile.setRatio(0).ratio).toBe(1);
+            expect(tile.setRatio(0.5).ratio).toBe(1);
+            expect(tile.setRatio(2.5).ratio).toBe(2);
+        });
+    });
+
+    describe('can compute', () => {
+        describe('the rotation angle for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleRight()).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_LEFT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleLeft()).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveAngle()).toMatchSnapshot();
+            });
+        });
+
+        describe('the side of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveSide()).toMatchSnapshot();
+            });
+        });
+
+        describe('the center of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveCenter()).toMatchSnapshot();
+                expect(tile.getCurveCenter(tileX, tileY)).toMatchSnapshot();
+            });
+        });
+
+        describe('the inner radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the outer radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks by side for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getSideBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the inner curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the outer curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the center point for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getCenterCoord()).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordRight()).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY, 90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordLeft()).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleRight()).toMatchSnapshot();
+                expect(tile.getOutputAngleRight(90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileEnlargedModel(specs, CurvedTileEnlargedModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleLeft()).toMatchSnapshot();
+                expect(tile.getOutputAngleLeft(90)).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/track/models/test/CurvedTileModel.spec.js
+++ b/src/track/models/test/CurvedTileModel.spec.js
@@ -1,0 +1,254 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CurvedTileModel } from '../CurvedTileModel.js';
+import { TileSpecifications } from '../TileSpecifications.js';
+
+const tileX = 100;
+const tileY = 100;
+const tileRatios = [0.5, 1, 2, 3, 4];
+const laneWidth = 80;
+const tileLength = 110;
+const tileWidth = 90;
+const barrierWidth = 5;
+const barrierChunks = 4;
+const specs = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+describe('CurvedTileModel', () => {
+    it('is a class', () => {
+        expect(CurvedTileModel).toEqual(expect.any(Function));
+    });
+
+    describe('throws error', () => {
+        it('when trying to create an instance with an invalid specifications object', () => {
+            // @ts-expect-error
+            expect(() => new CurvedTileModel({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to create an instance with an invalid direction', () => {
+            expect(() => new CurvedTileModel(specs, '')).toThrow('A valid direction is needed!');
+        });
+
+        it('when trying to set an invalid specifications object', () => {
+            const tile = new CurvedTileModel(specs);
+            // @ts-expect-error
+            expect(() => tile.setSpecs({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to set an invalid direction', () => {
+            const tile = new CurvedTileModel(specs);
+            expect(() => tile.setDirection('')).toThrow('A valid direction is needed!');
+        });
+    });
+
+    describe('can build a tile', () => {
+        it('with the given size', () => {
+            const tile = new CurvedTileModel(specs);
+
+            expect(tile).toBeInstanceOf(CurvedTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it('with the given size and direction', () => {
+            const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_LEFT);
+
+            expect(tile).toBeInstanceOf(CurvedTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it.each(tileRatios)('with the given size and a ratio of %s', ratio => {
+            const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_LEFT, ratio);
+
+            expect(tile).toBeInstanceOf(CurvedTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(CurvedTileModel.TYPE);
+            expect(tile.id).toBe(`${CurvedTileModel.TYPE}-${ratio}`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+    });
+
+    describe('can set', () => {
+        it('the specifications of the tile', () => {
+            const tile = new CurvedTileModel(specs);
+            const newSpecs = new TileSpecifications(10, 1, 2);
+
+            expect(tile.specs).toBeInstanceOf(TileSpecifications);
+            expect(tile.specs).not.toBe(newSpecs);
+            expect(tile.setSpecs(newSpecs)).toBe(tile);
+            expect(tile.specs).toBe(newSpecs);
+        });
+
+        it('the direction of the tile', () => {
+            const tile = new CurvedTileModel(specs);
+
+            expect(tile.direction).toBe(CurvedTileModel.DIRECTION_RIGHT);
+            expect(tile.setDirection(CurvedTileModel.DIRECTION_LEFT)).toBe(tile);
+            expect(tile.direction).toBe(CurvedTileModel.DIRECTION_LEFT);
+        });
+
+        it('the size ratio', () => {
+            const tile = new CurvedTileModel(specs);
+            expect(tile.setRatio(1)).toBe(tile);
+            expect(tile.ratio).toBe(1);
+            expect(tile.setRatio(-1).ratio).toBe(1);
+            expect(tile.setRatio(0).ratio).toBe(1);
+            expect(tile.setRatio(0.5).ratio).toBe(0.5);
+            expect(tile.setRatio(2.5).ratio).toBe(2.5);
+        });
+    });
+
+    describe('can compute', () => {
+        describe('the rotation angle for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleRight()).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_LEFT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleLeft()).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveAngle()).toMatchSnapshot();
+            });
+        });
+
+        describe('the side of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveSide()).toMatchSnapshot();
+            });
+        });
+
+        describe('the center of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveCenter()).toMatchSnapshot();
+                expect(tile.getCurveCenter(tileX, tileY)).toMatchSnapshot();
+            });
+        });
+
+        describe('the inner radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the outer radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks by side for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getSideBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the inner curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the outer curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the center point for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getCenterCoord()).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordRight()).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY, 90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordLeft()).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleRight()).toMatchSnapshot();
+                expect(tile.getOutputAngleRight(90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new CurvedTileModel(specs, CurvedTileModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleLeft()).toMatchSnapshot();
+                expect(tile.getOutputAngleLeft(90)).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/track/models/test/StraightTileModel.spec.js
+++ b/src/track/models/test/StraightTileModel.spec.js
@@ -1,0 +1,254 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { StraightTileModel } from '../StraightTileModel.js';
+import { TileSpecifications } from '../TileSpecifications.js';
+
+const tileX = 100;
+const tileY = 100;
+const tileRatios = [0.5, 1, 2, 3, 4];
+const laneWidth = 80;
+const tileLength = 110;
+const tileWidth = 90;
+const barrierWidth = 5;
+const barrierChunks = 4;
+const specs = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+describe('StraightTileModel', () => {
+    it('is a class', () => {
+        expect(StraightTileModel).toEqual(expect.any(Function));
+    });
+
+    describe('throws error', () => {
+        it('when trying to create an instance with an invalid specifications object', () => {
+            // @ts-expect-error
+            expect(() => new StraightTileModel({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to create an instance with an invalid direction', () => {
+            expect(() => new StraightTileModel(specs, '')).toThrow('A valid direction is needed!');
+        });
+
+        it('when trying to set an invalid specifications object', () => {
+            const tile = new StraightTileModel(specs);
+            // @ts-expect-error
+            expect(() => tile.setSpecs({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to set an invalid direction', () => {
+            const tile = new StraightTileModel(specs);
+            expect(() => tile.setDirection('')).toThrow('A valid direction is needed!');
+        });
+    });
+
+    describe('can build a tile', () => {
+        it('with the given size', () => {
+            const tile = new StraightTileModel(specs);
+
+            expect(tile).toBeInstanceOf(StraightTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(StraightTileModel.TYPE);
+            expect(tile.id).toBe(`${StraightTileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it('with the given size and direction', () => {
+            const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_LEFT);
+
+            expect(tile).toBeInstanceOf(StraightTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(StraightTileModel.TYPE);
+            expect(tile.id).toBe(`${StraightTileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it.each(tileRatios)('with the given size and a ratio of %s', ratio => {
+            const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_LEFT, ratio);
+
+            expect(tile).toBeInstanceOf(StraightTileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(StraightTileModel.TYPE);
+            expect(tile.id).toBe(`${StraightTileModel.TYPE}-${ratio}`);
+            expect(tile.length).toBe(tileLength * ratio);
+            expect(tile.width).toBe(tileWidth);
+        });
+    });
+
+    describe('can set', () => {
+        it('the specifications of the tile', () => {
+            const tile = new StraightTileModel(specs);
+            const newSpecs = new TileSpecifications(10, 1, 2);
+
+            expect(tile.specs).toBeInstanceOf(TileSpecifications);
+            expect(tile.specs).not.toBe(newSpecs);
+            expect(tile.setSpecs(newSpecs)).toBe(tile);
+            expect(tile.specs).toBe(newSpecs);
+        });
+
+        it('the direction of the tile', () => {
+            const tile = new StraightTileModel(specs);
+
+            expect(tile.direction).toBe(StraightTileModel.DIRECTION_RIGHT);
+            expect(tile.setDirection(StraightTileModel.DIRECTION_LEFT)).toBe(tile);
+            expect(tile.direction).toBe(StraightTileModel.DIRECTION_LEFT);
+        });
+
+        it('the size ratio', () => {
+            const tile = new StraightTileModel(specs);
+            expect(tile.setRatio(1)).toBe(tile);
+            expect(tile.ratio).toBe(1);
+            expect(tile.setRatio(-1).ratio).toBe(1);
+            expect(tile.setRatio(0).ratio).toBe(1);
+            expect(tile.setRatio(0.5).ratio).toBe(0.5);
+            expect(tile.setRatio(2.5).ratio).toBe(2.5);
+        });
+    });
+
+    describe('can compute', () => {
+        describe('the rotation angle for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleRight()).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_LEFT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleLeft()).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveAngle()).toMatchSnapshot();
+            });
+        });
+
+        describe('the side of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveSide()).toMatchSnapshot();
+            });
+        });
+
+        describe('the center of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveCenter()).toMatchSnapshot();
+                expect(tile.getCurveCenter(tileX, tileY)).toMatchSnapshot();
+            });
+        });
+
+        describe('the inner radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the outer radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks by side for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getSideBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the inner curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the outer curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the center point for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getCenterCoord()).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordRight()).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY, 90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordLeft()).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleRight()).toMatchSnapshot();
+                expect(tile.getOutputAngleRight(90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new StraightTileModel(specs, StraightTileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleLeft()).toMatchSnapshot();
+                expect(tile.getOutputAngleLeft(90)).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/track/models/test/TileModel.spec.js
+++ b/src/track/models/test/TileModel.spec.js
@@ -1,0 +1,254 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TileModel } from '../TileModel.js';
+import { TileSpecifications } from '../TileSpecifications.js';
+
+const tileX = 100;
+const tileY = 100;
+const tileRatios = [0.5, 1, 2, 3, 4];
+const laneWidth = 80;
+const tileLength = 110;
+const tileWidth = 90;
+const barrierWidth = 5;
+const barrierChunks = 4;
+const specs = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+describe('TileModel', () => {
+    it('is a class', () => {
+        expect(TileModel).toEqual(expect.any(Function));
+    });
+
+    describe('throws error', () => {
+        it('when trying to create an instance with an invalid specifications object', () => {
+            // @ts-expect-error
+            expect(() => new TileModel({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to create an instance with an invalid direction', () => {
+            expect(() => new TileModel(specs, '')).toThrow('A valid direction is needed!');
+        });
+
+        it('when trying to set an invalid specifications object', () => {
+            const tile = new TileModel(specs);
+            // @ts-expect-error
+            expect(() => tile.setSpecs({})).toThrow('A valid specifications object is needed!');
+        });
+
+        it('when trying to set an invalid direction', () => {
+            const tile = new TileModel(specs);
+            expect(() => tile.setDirection('')).toThrow('A valid direction is needed!');
+        });
+    });
+
+    describe('can build a tile', () => {
+        it('with the given size', () => {
+            const tile = new TileModel(specs);
+
+            expect(tile).toBeInstanceOf(TileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(TileModel.TYPE);
+            expect(tile.id).toBe(`${TileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it('with the given size and direction', () => {
+            const tile = new TileModel(specs, TileModel.DIRECTION_LEFT);
+
+            expect(tile).toBeInstanceOf(TileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(TileModel.TYPE);
+            expect(tile.id).toBe(`${TileModel.TYPE}-1`);
+            expect(tile.length).toBe(tileLength);
+            expect(tile.width).toBe(tileWidth);
+        });
+
+        it.each(tileRatios)('with the given size and a ratio of %s', ratio => {
+            const tile = new TileModel(specs, TileModel.DIRECTION_LEFT, ratio);
+
+            expect(tile).toBeInstanceOf(TileModel);
+            expect(tile).toMatchSnapshot();
+            expect(tile.type).toBe(TileModel.TYPE);
+            expect(tile.id).toBe(`${TileModel.TYPE}-${ratio}`);
+            expect(tile.length).toBe(tileLength * ratio);
+            expect(tile.width).toBe(tileWidth * ratio);
+        });
+    });
+
+    describe('can set', () => {
+        it('the specifications of the tile', () => {
+            const tile = new TileModel(specs);
+            const newSpecs = new TileSpecifications(10, 1, 2);
+
+            expect(tile.specs).toBeInstanceOf(TileSpecifications);
+            expect(tile.specs).not.toBe(newSpecs);
+            expect(tile.setSpecs(newSpecs)).toBe(tile);
+            expect(tile.specs).toBe(newSpecs);
+        });
+
+        it('the direction of the tile', () => {
+            const tile = new TileModel(specs);
+
+            expect(tile.direction).toBe(TileModel.DIRECTION_RIGHT);
+            expect(tile.setDirection(TileModel.DIRECTION_LEFT)).toBe(tile);
+            expect(tile.direction).toBe(TileModel.DIRECTION_LEFT);
+        });
+
+        it('the size ratio', () => {
+            const tile = new TileModel(specs);
+            expect(tile.setRatio(1)).toBe(tile);
+            expect(tile.ratio).toBe(1);
+            expect(tile.setRatio(-1).ratio).toBe(1);
+            expect(tile.setRatio(0).ratio).toBe(1);
+            expect(tile.setRatio(0.5).ratio).toBe(0.5);
+            expect(tile.setRatio(2.5).ratio).toBe(2.5);
+        });
+    });
+
+    describe('can compute', () => {
+        describe('the rotation angle for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleRight()).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_LEFT, ratio);
+                expect(tile.getDirectionAngle()).toMatchSnapshot();
+                expect(tile.getDirectionAngleLeft()).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveAngle()).toMatchSnapshot();
+            });
+        });
+
+        describe('the side of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveSide()).toMatchSnapshot();
+            });
+        });
+
+        describe('the center of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getCurveCenter()).toMatchSnapshot();
+                expect(tile.getCurveCenter(tileX, tileY)).toMatchSnapshot();
+            });
+        });
+
+        describe('the inner radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the outer radius of the curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterRadius()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks by side for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getSideBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the inner curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getInnerBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the number of chunks for the outer curve for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+                expect(tile.getOuterBarrierChunks()).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the center point for a tile', () => {
+            it.each(tileRatios)('with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getCenterCoord()).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getCenterCoord(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the position of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordRight()).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordRight(tileX, tileY, 90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputCoord()).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoord(tileX, tileY, 90)).toMatchSnapshot();
+
+                expect(tile.getOutputCoordLeft()).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY)).toMatchSnapshot();
+                expect(tile.getOutputCoordLeft(tileX, tileY, 90)).toMatchSnapshot();
+            });
+        });
+
+        describe('the angle of the output point for a tile', () => {
+            it.each(tileRatios)('oriented to the right with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_RIGHT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleRight()).toMatchSnapshot();
+                expect(tile.getOutputAngleRight(90)).toMatchSnapshot();
+            });
+
+            it.each(tileRatios)('oriented to the left with a ratio of %s', ratio => {
+                const tile = new TileModel(specs, TileModel.DIRECTION_LEFT, ratio);
+
+                expect(tile.getOutputAngle()).toMatchSnapshot();
+                expect(tile.getOutputAngle(90)).toMatchSnapshot();
+
+                expect(tile.getOutputAngleLeft()).toMatchSnapshot();
+                expect(tile.getOutputAngleLeft(90)).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/track/models/test/TileSpecifications.spec.js
+++ b/src/track/models/test/TileSpecifications.spec.js
@@ -1,0 +1,80 @@
+/**
+ * RC Tracks Editor
+ * Copyright (c) 2022 Jean-Sébastien CONAN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TileSpecifications } from '../TileSpecifications.js';
+
+const laneWidth = 80;
+const tileLength = 110;
+const tileWidth = 90;
+const tilePadding = 10;
+const barrierLength = 27.5;
+const barrierWidth = 5;
+const barrierChunks = 4;
+
+describe('TileSpecifications', () => {
+    it('is a class', () => {
+        expect(TileSpecifications).toEqual(expect.any(Function));
+    });
+
+    it('defines the specifications for the tiles', () => {
+        const tile = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+        expect(tile).toBeInstanceOf(TileSpecifications);
+        expect(tile.laneWidth).toBe(laneWidth);
+        expect(tile.barrierWidth).toBe(barrierWidth);
+        expect(tile.barrierChunks).toBe(barrierChunks);
+        expect(tile.length).toBe(tileLength);
+        expect(tile.width).toBe(tileWidth);
+        expect(tile.padding).toBe(tilePadding);
+        expect(tile.barrierLength).toBe(barrierLength);
+    });
+
+    describe('can set', () => {
+        it.each([
+            [50, 50],
+            [-60, 60]
+        ])('the width of the track lane as %s, actually %s', (value, expected) => {
+            const tile = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+
+            expect(tile.setLaneWidth(value)).toBe(tile);
+            expect(tile.laneWidth).toBe(expected);
+        });
+
+        it.each([
+            [3, 3],
+            [-4, 4]
+        ])('the width of a barrier as %s, actually %s', (value, expected) => {
+            const tile = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+            expect(tile.setBarrierWidth(value)).toBe(tile);
+            expect(tile.barrierWidth).toBe(expected);
+        });
+
+        it.each([
+            [1, 1],
+            [-1, 1],
+            [0, 1],
+            [0.1, 1],
+            [1.8, 2],
+            [2.1, 2]
+        ])('the number of a barrier chunks as %s, actually %s', (value, expected) => {
+            const tile = new TileSpecifications(laneWidth, barrierWidth, barrierChunks);
+            expect(tile.setBarrierChunks(value)).toBe(tile);
+            expect(tile.barrierChunks).toBe(expected);
+        });
+    });
+});

--- a/src/track/models/test/__snapshots__/CurvedTileEnlargedModel.spec.js.snap
+++ b/src/track/models/test/__snapshots__/CurvedTileEnlargedModel.spec.js.snap
@@ -1,0 +1,870 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "right",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and a ratio of 0.5 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and a ratio of 1 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and a ratio of 2 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 2,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and a ratio of 3 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 3,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and a ratio of 4 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 4,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can build a tile with the given size and direction 1`] = `
+CurvedTileEnlargedModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the curve for a tile with a ratio of 0.5 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the curve for a tile with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the curve for a tile with a ratio of 2 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the curve for a tile with a ratio of 3 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the curve for a tile with a ratio of 4 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 1`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 3`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 4`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 1`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 3`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 4`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 1`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 3`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 4`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 1`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 3`] = `-90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 4`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 2`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 3`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 4`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 2`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 3`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 4`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 2`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 3`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 4`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 2`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 3`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 4`] = `180`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": -165,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": -65,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": -275,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": -175,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": -385,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the center of the curve for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": -285,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the inner radius of the curve for a tile with a ratio of 0.5 1`] = `10`;
+
+exports[`CurvedTileEnlargedModel can compute the inner radius of the curve for a tile with a ratio of 1 1`] = `10`;
+
+exports[`CurvedTileEnlargedModel can compute the inner radius of the curve for a tile with a ratio of 2 1`] = `120`;
+
+exports[`CurvedTileEnlargedModel can compute the inner radius of the curve for a tile with a ratio of 3 1`] = `230`;
+
+exports[`CurvedTileEnlargedModel can compute the inner radius of the curve for a tile with a ratio of 4 1`] = `340`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks by side for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks by side for a tile with a ratio of 1 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks by side for a tile with a ratio of 2 1`] = `4`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks by side for a tile with a ratio of 3 1`] = `6`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks by side for a tile with a ratio of 4 1`] = `8`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the inner curve for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the inner curve for a tile with a ratio of 1 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the inner curve for a tile with a ratio of 2 1`] = `8`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the inner curve for a tile with a ratio of 3 1`] = `12`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the inner curve for a tile with a ratio of 4 1`] = `16`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the outer curve for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the outer curve for a tile with a ratio of 1 1`] = `2`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the outer curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the outer curve for a tile with a ratio of 3 1`] = `6`;
+
+exports[`CurvedTileEnlargedModel can compute the number of chunks for the outer curve for a tile with a ratio of 4 1`] = `8`;
+
+exports[`CurvedTileEnlargedModel can compute the outer radius of the curve for a tile with a ratio of 0.5 1`] = `45`;
+
+exports[`CurvedTileEnlargedModel can compute the outer radius of the curve for a tile with a ratio of 1 1`] = `45`;
+
+exports[`CurvedTileEnlargedModel can compute the outer radius of the curve for a tile with a ratio of 2 1`] = `100`;
+
+exports[`CurvedTileEnlargedModel can compute the outer radius of the curve for a tile with a ratio of 3 1`] = `155`;
+
+exports[`CurvedTileEnlargedModel can compute the outer radius of the curve for a tile with a ratio of 4 1`] = `210`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 165,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 2 3`] = `
+Vector2D {
+  "x": -65,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 275,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 3 3`] = `
+Vector2D {
+  "x": -175,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 385,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the center point for a tile with a ratio of 4 3`] = `
+Vector2D {
+  "x": -285,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 1`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 2`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 4`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 5`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 1`] = `
+Vector2D {
+  "x": 165,
+  "y": 165,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 2`] = `
+Vector2D {
+  "x": 265,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 3`] = `
+Vector2D {
+  "x": -65,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 4`] = `
+Vector2D {
+  "x": 165,
+  "y": 165,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 5`] = `
+Vector2D {
+  "x": 265,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 6`] = `
+Vector2D {
+  "x": -65,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 1`] = `
+Vector2D {
+  "x": 275,
+  "y": 275,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 2`] = `
+Vector2D {
+  "x": 375,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 3`] = `
+Vector2D {
+  "x": -175,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 4`] = `
+Vector2D {
+  "x": 275,
+  "y": 275,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 5`] = `
+Vector2D {
+  "x": 375,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 6`] = `
+Vector2D {
+  "x": -175,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 1`] = `
+Vector2D {
+  "x": 385,
+  "y": 385,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 2`] = `
+Vector2D {
+  "x": 485,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 3`] = `
+Vector2D {
+  "x": -285,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 4`] = `
+Vector2D {
+  "x": 385,
+  "y": 385,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 5`] = `
+Vector2D {
+  "x": 485,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 6`] = `
+Vector2D {
+  "x": -285,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 4`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 5`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 1`] = `
+Vector2D {
+  "x": -165,
+  "y": 165,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 2`] = `
+Vector2D {
+  "x": -65,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 3`] = `
+Vector2D {
+  "x": -65,
+  "y": -65,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 4`] = `
+Vector2D {
+  "x": -165,
+  "y": 165,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 5`] = `
+Vector2D {
+  "x": -65,
+  "y": 265,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 6`] = `
+Vector2D {
+  "x": -65,
+  "y": -65,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 1`] = `
+Vector2D {
+  "x": -275,
+  "y": 275,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 2`] = `
+Vector2D {
+  "x": -175,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 3`] = `
+Vector2D {
+  "x": -175,
+  "y": -175,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 4`] = `
+Vector2D {
+  "x": -275,
+  "y": 275,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 5`] = `
+Vector2D {
+  "x": -175,
+  "y": 375,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 6`] = `
+Vector2D {
+  "x": -175,
+  "y": -175,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 1`] = `
+Vector2D {
+  "x": -385,
+  "y": 385,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 2`] = `
+Vector2D {
+  "x": -285,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 3`] = `
+Vector2D {
+  "x": -285,
+  "y": -285,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 4`] = `
+Vector2D {
+  "x": -385,
+  "y": 385,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 5`] = `
+Vector2D {
+  "x": -285,
+  "y": 485,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 6`] = `
+Vector2D {
+  "x": -285,
+  "y": -285,
+}
+`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 2`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 2`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 2`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 2`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 1`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 2`] = `90`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 2`] = `0`;
+
+exports[`CurvedTileEnlargedModel can compute the side of the curve for a tile with a ratio of 0.5 1`] = `55`;
+
+exports[`CurvedTileEnlargedModel can compute the side of the curve for a tile with a ratio of 1 1`] = `55`;
+
+exports[`CurvedTileEnlargedModel can compute the side of the curve for a tile with a ratio of 2 1`] = `110`;
+
+exports[`CurvedTileEnlargedModel can compute the side of the curve for a tile with a ratio of 3 1`] = `165`;
+
+exports[`CurvedTileEnlargedModel can compute the side of the curve for a tile with a ratio of 4 1`] = `220`;

--- a/src/track/models/test/__snapshots__/CurvedTileModel.spec.js.snap
+++ b/src/track/models/test/__snapshots__/CurvedTileModel.spec.js.snap
@@ -1,0 +1,870 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurvedTileModel can build a tile with the given size 1`] = `
+CurvedTileModel {
+  "direction": "right",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and a ratio of 0.5 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 0.5,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and a ratio of 1 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and a ratio of 2 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 2,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and a ratio of 3 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 3,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and a ratio of 4 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 4,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can build a tile with the given size and direction 1`] = `
+CurvedTileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`CurvedTileModel can compute the angle of the curve for a tile with a ratio of 0.5 1`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the curve for a tile with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileModel can compute the angle of the curve for a tile with a ratio of 2 1`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the curve for a tile with a ratio of 3 1`] = `30`;
+
+exports[`CurvedTileModel can compute the angle of the curve for a tile with a ratio of 4 1`] = `22.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `-45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `-45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 1`] = `-90`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 2`] = `0`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 3`] = `-90`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 4`] = `0`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 1`] = `-45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 2`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 3`] = `-45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 4`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 1`] = `-30`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 2`] = `60`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 3`] = `-30`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 4`] = `60`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 1`] = `-22.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 2`] = `67.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 3`] = `-22.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 4`] = `67.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `135`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `135`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 2`] = `180`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 3`] = `90`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 4`] = `180`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 1`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 2`] = `135`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 3`] = `45`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 4`] = `135`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 1`] = `30`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 2`] = `120`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 3`] = `30`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 4`] = `120`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 1`] = `22.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 2`] = `112.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 3`] = `22.5`;
+
+exports[`CurvedTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 4`] = `112.5`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": -165,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": -65,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": -275,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": -175,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": -385,
+  "y": 0,
+}
+`;
+
+exports[`CurvedTileModel can compute the center of the curve for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": -285,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the inner radius of the curve for a tile with a ratio of 0.5 1`] = `10`;
+
+exports[`CurvedTileModel can compute the inner radius of the curve for a tile with a ratio of 1 1`] = `10`;
+
+exports[`CurvedTileModel can compute the inner radius of the curve for a tile with a ratio of 2 1`] = `120`;
+
+exports[`CurvedTileModel can compute the inner radius of the curve for a tile with a ratio of 3 1`] = `230`;
+
+exports[`CurvedTileModel can compute the inner radius of the curve for a tile with a ratio of 4 1`] = `340`;
+
+exports[`CurvedTileModel can compute the number of chunks by side for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`CurvedTileModel can compute the number of chunks by side for a tile with a ratio of 1 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks by side for a tile with a ratio of 2 1`] = `8`;
+
+exports[`CurvedTileModel can compute the number of chunks by side for a tile with a ratio of 3 1`] = `12`;
+
+exports[`CurvedTileModel can compute the number of chunks by side for a tile with a ratio of 4 1`] = `16`;
+
+exports[`CurvedTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 0.5 1`] = `1`;
+
+exports[`CurvedTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 1 1`] = `2`;
+
+exports[`CurvedTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`CurvedTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 1 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`CurvedTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`CurvedTileModel can compute the outer radius of the curve for a tile with a ratio of 0.5 1`] = `100`;
+
+exports[`CurvedTileModel can compute the outer radius of the curve for a tile with a ratio of 1 1`] = `100`;
+
+exports[`CurvedTileModel can compute the outer radius of the curve for a tile with a ratio of 2 1`] = `210`;
+
+exports[`CurvedTileModel can compute the outer radius of the curve for a tile with a ratio of 3 1`] = `320`;
+
+exports[`CurvedTileModel can compute the outer radius of the curve for a tile with a ratio of 4 1`] = `430`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 22.781745930520216,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 122.78174593052023,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 77.21825406947977,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 68.34523779156069,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 168.34523779156066,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 2 3`] = `
+Vector2D {
+  "x": 31.654762208439337,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 73.6860279185587,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 173.68602791855866,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 3 3`] = `
+Vector2D {
+  "x": 26.313972081441335,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 76.58126144116827,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 176.58126144116827,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the center point for a tile with a ratio of 4 3`] = `
+Vector2D {
+  "x": 23.418738558831734,
+  "y": 100,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 16.109127034739892,
+  "y": 38.890872965260115,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 116.10912703473988,
+  "y": 138.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 61.109127034739885,
+  "y": 116.10912703473988,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 16.109127034739892,
+  "y": 38.890872965260115,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 116.10912703473988,
+  "y": 138.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 61.109127034739885,
+  "y": 116.10912703473988,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 1`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 2`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 4`] = `
+Vector2D {
+  "x": 55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 5`] = `
+Vector2D {
+  "x": 155,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 1`] = `
+Vector2D {
+  "x": 48.32738110421967,
+  "y": 116.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 2`] = `
+Vector2D {
+  "x": 148.32738110421968,
+  "y": 216.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 3`] = `
+Vector2D {
+  "x": -16.672618895780346,
+  "y": 148.32738110421968,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 4`] = `
+Vector2D {
+  "x": 48.32738110421967,
+  "y": 116.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 5`] = `
+Vector2D {
+  "x": 148.32738110421968,
+  "y": 216.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 6`] = `
+Vector2D {
+  "x": -16.672618895780346,
+  "y": 148.32738110421968,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 1`] = `
+Vector2D {
+  "x": 36.84301395927935,
+  "y": 137.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 2`] = `
+Vector2D {
+  "x": 136.84301395927935,
+  "y": 237.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 3`] = `
+Vector2D {
+  "x": -37.49999999999997,
+  "y": 136.84301395927935,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 4`] = `
+Vector2D {
+  "x": 36.84301395927935,
+  "y": 137.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 5`] = `
+Vector2D {
+  "x": 136.84301395927935,
+  "y": 237.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 6`] = `
+Vector2D {
+  "x": -37.49999999999997,
+  "y": 136.84301395927935,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 1`] = `
+Vector2D {
+  "x": 29.306379983154613,
+  "y": 147.3331214605596,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 2`] = `
+Vector2D {
+  "x": 129.3063799831546,
+  "y": 247.3331214605596,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 3`] = `
+Vector2D {
+  "x": -47.333121460559596,
+  "y": 129.3063799831546,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 4`] = `
+Vector2D {
+  "x": 29.306379983154613,
+  "y": 147.3331214605596,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 5`] = `
+Vector2D {
+  "x": 129.3063799831546,
+  "y": 247.3331214605596,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 6`] = `
+Vector2D {
+  "x": -47.333121460559596,
+  "y": 129.3063799831546,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -16.109127034739885,
+  "y": 38.89087296526011,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 83.89087296526012,
+  "y": 138.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 61.109127034739885,
+  "y": 83.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": -16.109127034739885,
+  "y": 38.89087296526011,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 83.89087296526012,
+  "y": 138.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 61.109127034739885,
+  "y": 83.89087296526012,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 4`] = `
+Vector2D {
+  "x": -55,
+  "y": 55,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 5`] = `
+Vector2D {
+  "x": 45,
+  "y": 155,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 45,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 1`] = `
+Vector2D {
+  "x": -48.327381104219654,
+  "y": 116.67261889578033,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 2`] = `
+Vector2D {
+  "x": 51.672618895780346,
+  "y": 216.67261889578032,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 3`] = `
+Vector2D {
+  "x": -16.672618895780317,
+  "y": 51.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 4`] = `
+Vector2D {
+  "x": -48.327381104219654,
+  "y": 116.67261889578033,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 5`] = `
+Vector2D {
+  "x": 51.672618895780346,
+  "y": 216.67261889578032,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 6`] = `
+Vector2D {
+  "x": -16.672618895780317,
+  "y": 51.67261889578035,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 1`] = `
+Vector2D {
+  "x": -36.84301395927935,
+  "y": 137.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 2`] = `
+Vector2D {
+  "x": 63.15698604072065,
+  "y": 237.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 3`] = `
+Vector2D {
+  "x": -37.49999999999997,
+  "y": 63.15698604072066,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 4`] = `
+Vector2D {
+  "x": -36.84301395927935,
+  "y": 137.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 5`] = `
+Vector2D {
+  "x": 63.15698604072065,
+  "y": 237.49999999999997,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 6`] = `
+Vector2D {
+  "x": -37.49999999999997,
+  "y": 63.15698604072066,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 1`] = `
+Vector2D {
+  "x": -29.306379983154613,
+  "y": 147.33312146055957,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 2`] = `
+Vector2D {
+  "x": 70.69362001684539,
+  "y": 247.33312146055957,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 3`] = `
+Vector2D {
+  "x": -47.33312146055957,
+  "y": 70.6936200168454,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 4`] = `
+Vector2D {
+  "x": -29.306379983154613,
+  "y": 147.33312146055957,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 5`] = `
+Vector2D {
+  "x": 70.69362001684539,
+  "y": 247.33312146055957,
+}
+`;
+
+exports[`CurvedTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 6`] = `
+Vector2D {
+  "x": -47.33312146055957,
+  "y": 70.6936200168454,
+}
+`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 1`] = `90`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 2`] = `90`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 1`] = `90`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 2`] = `90`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 1`] = `135`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 2`] = `135`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 1`] = `150`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 2`] = `150`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 1`] = `157.5`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 2`] = `157.5`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 2`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 2`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 2`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 2`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`CurvedTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 2`] = `0`;
+
+exports[`CurvedTileModel can compute the side of the curve for a tile with a ratio of 0.5 1`] = `0`;
+
+exports[`CurvedTileModel can compute the side of the curve for a tile with a ratio of 1 1`] = `0`;
+
+exports[`CurvedTileModel can compute the side of the curve for a tile with a ratio of 2 1`] = `0`;
+
+exports[`CurvedTileModel can compute the side of the curve for a tile with a ratio of 3 1`] = `0`;
+
+exports[`CurvedTileModel can compute the side of the curve for a tile with a ratio of 4 1`] = `0`;

--- a/src/track/models/test/__snapshots__/StraightTileModel.spec.js.snap
+++ b/src/track/models/test/__snapshots__/StraightTileModel.spec.js.snap
@@ -1,0 +1,870 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StraightTileModel can build a tile with the given size 1`] = `
+StraightTileModel {
+  "direction": "right",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and a ratio of 0.5 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 0.5,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and a ratio of 1 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and a ratio of 2 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 2,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and a ratio of 3 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 3,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and a ratio of 4 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 4,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can build a tile with the given size and direction 1`] = `
+StraightTileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`StraightTileModel can compute the angle of the curve for a tile with a ratio of 0.5 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the curve for a tile with a ratio of 1 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the curve for a tile with a ratio of 2 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the curve for a tile with a ratio of 3 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the curve for a tile with a ratio of 4 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 4`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 2`] = `90`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 3`] = `0`;
+
+exports[`StraightTileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 4`] = `90`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": -165,
+  "y": 0,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": -65,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": -275,
+  "y": 0,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": -175,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": -385,
+  "y": 0,
+}
+`;
+
+exports[`StraightTileModel can compute the center of the curve for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": -285,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the inner radius of the curve for a tile with a ratio of 0.5 1`] = `10`;
+
+exports[`StraightTileModel can compute the inner radius of the curve for a tile with a ratio of 1 1`] = `10`;
+
+exports[`StraightTileModel can compute the inner radius of the curve for a tile with a ratio of 2 1`] = `120`;
+
+exports[`StraightTileModel can compute the inner radius of the curve for a tile with a ratio of 3 1`] = `230`;
+
+exports[`StraightTileModel can compute the inner radius of the curve for a tile with a ratio of 4 1`] = `340`;
+
+exports[`StraightTileModel can compute the number of chunks by side for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`StraightTileModel can compute the number of chunks by side for a tile with a ratio of 1 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks by side for a tile with a ratio of 2 1`] = `8`;
+
+exports[`StraightTileModel can compute the number of chunks by side for a tile with a ratio of 3 1`] = `12`;
+
+exports[`StraightTileModel can compute the number of chunks by side for a tile with a ratio of 4 1`] = `16`;
+
+exports[`StraightTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 0.5 1`] = `1`;
+
+exports[`StraightTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 1 1`] = `2`;
+
+exports[`StraightTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the inner curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`StraightTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 1 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`StraightTileModel can compute the number of chunks for the outer curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`StraightTileModel can compute the outer radius of the curve for a tile with a ratio of 0.5 1`] = `100`;
+
+exports[`StraightTileModel can compute the outer radius of the curve for a tile with a ratio of 1 1`] = `100`;
+
+exports[`StraightTileModel can compute the outer radius of the curve for a tile with a ratio of 2 1`] = `210`;
+
+exports[`StraightTileModel can compute the outer radius of the curve for a tile with a ratio of 3 1`] = `320`;
+
+exports[`StraightTileModel can compute the outer radius of the curve for a tile with a ratio of 4 1`] = `430`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 27.5,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 127.5,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 72.5,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 2 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 165,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 265,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 3 3`] = `
+Vector2D {
+  "x": -65,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the center point for a tile with a ratio of 4 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 6`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 6`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 3`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 6`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 3`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 6`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 6`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 6`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 3`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 6`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 3`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`StraightTileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 6`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 1`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 2`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 1`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 2`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 1`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 2`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 1`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 2`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 1`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 2`] = `180`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 2`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 2`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 2`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 2`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`StraightTileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 2`] = `0`;
+
+exports[`StraightTileModel can compute the side of the curve for a tile with a ratio of 0.5 1`] = `0`;
+
+exports[`StraightTileModel can compute the side of the curve for a tile with a ratio of 1 1`] = `0`;
+
+exports[`StraightTileModel can compute the side of the curve for a tile with a ratio of 2 1`] = `0`;
+
+exports[`StraightTileModel can compute the side of the curve for a tile with a ratio of 3 1`] = `0`;
+
+exports[`StraightTileModel can compute the side of the curve for a tile with a ratio of 4 1`] = `0`;

--- a/src/track/models/test/__snapshots__/TileModel.spec.js.snap
+++ b/src/track/models/test/__snapshots__/TileModel.spec.js.snap
@@ -1,0 +1,870 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TileModel can build a tile with the given size 1`] = `
+TileModel {
+  "direction": "right",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and a ratio of 0.5 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 0.5,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and a ratio of 1 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and a ratio of 2 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 2,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and a ratio of 3 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 3,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and a ratio of 4 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 4,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can build a tile with the given size and direction 1`] = `
+TileModel {
+  "direction": "left",
+  "ratio": 1,
+  "specs": TileSpecifications {
+    "barrierChunks": 4,
+    "barrierWidth": 5,
+    "laneWidth": 80,
+  },
+}
+`;
+
+exports[`TileModel can compute the angle of the curve for a tile with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the angle of the curve for a tile with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the angle of the curve for a tile with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the angle of the curve for a tile with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the angle of the curve for a tile with a ratio of 4 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 1 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 2 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 3 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the left with a ratio of 4 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 1 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 2 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 3 4`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 2`] = `90`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 3`] = `0`;
+
+exports[`TileModel can compute the angle of the output point for a tile oriented to the right with a ratio of 4 4`] = `90`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": -55,
+  "y": 0,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": -165,
+  "y": 0,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": -65,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": -275,
+  "y": 0,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": -175,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": -385,
+  "y": 0,
+}
+`;
+
+exports[`TileModel can compute the center of the curve for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": -285,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the inner radius of the curve for a tile with a ratio of 0.5 1`] = `10`;
+
+exports[`TileModel can compute the inner radius of the curve for a tile with a ratio of 1 1`] = `10`;
+
+exports[`TileModel can compute the inner radius of the curve for a tile with a ratio of 2 1`] = `120`;
+
+exports[`TileModel can compute the inner radius of the curve for a tile with a ratio of 3 1`] = `230`;
+
+exports[`TileModel can compute the inner radius of the curve for a tile with a ratio of 4 1`] = `340`;
+
+exports[`TileModel can compute the number of chunks by side for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`TileModel can compute the number of chunks by side for a tile with a ratio of 1 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks by side for a tile with a ratio of 2 1`] = `8`;
+
+exports[`TileModel can compute the number of chunks by side for a tile with a ratio of 3 1`] = `12`;
+
+exports[`TileModel can compute the number of chunks by side for a tile with a ratio of 4 1`] = `16`;
+
+exports[`TileModel can compute the number of chunks for the inner curve for a tile with a ratio of 0.5 1`] = `1`;
+
+exports[`TileModel can compute the number of chunks for the inner curve for a tile with a ratio of 1 1`] = `2`;
+
+exports[`TileModel can compute the number of chunks for the inner curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the inner curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the inner curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the outer curve for a tile with a ratio of 0.5 1`] = `2`;
+
+exports[`TileModel can compute the number of chunks for the outer curve for a tile with a ratio of 1 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the outer curve for a tile with a ratio of 2 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the outer curve for a tile with a ratio of 3 1`] = `4`;
+
+exports[`TileModel can compute the number of chunks for the outer curve for a tile with a ratio of 4 1`] = `4`;
+
+exports[`TileModel can compute the outer radius of the curve for a tile with a ratio of 0.5 1`] = `100`;
+
+exports[`TileModel can compute the outer radius of the curve for a tile with a ratio of 1 1`] = `100`;
+
+exports[`TileModel can compute the outer radius of the curve for a tile with a ratio of 2 1`] = `210`;
+
+exports[`TileModel can compute the outer radius of the curve for a tile with a ratio of 3 1`] = `320`;
+
+exports[`TileModel can compute the outer radius of the curve for a tile with a ratio of 4 1`] = `430`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 27.5,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 127.5,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 72.5,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 1 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 2 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 165,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 265,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 3 3`] = `
+Vector2D {
+  "x": -65,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`TileModel can compute the position of the center point for a tile with a ratio of 4 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 1 6`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 2 6`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 3`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 3 6`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 3`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the left with a ratio of 4 6`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 3`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 55,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 155,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 0.5 6`] = `
+Vector2D {
+  "x": 45,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 3`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 110,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 210,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 1 6`] = `
+Vector2D {
+  "x": -10,
+  "y": 100,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 3`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 220,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 320,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 2 6`] = `
+Vector2D {
+  "x": -120,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 3`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 330,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 430,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 3 6`] = `
+Vector2D {
+  "x": -230,
+  "y": 100.00000000000001,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 1`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 2`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 3`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 4`] = `
+Vector2D {
+  "x": 0,
+  "y": 440,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 5`] = `
+Vector2D {
+  "x": 100,
+  "y": 540,
+}
+`;
+
+exports[`TileModel can compute the position of the output point for a tile oriented to the right with a ratio of 4 6`] = `
+Vector2D {
+  "x": -340,
+  "y": 100.00000000000003,
+}
+`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 0.5 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 1 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 2 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 3 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the left with a ratio of 4 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 0.5 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 1 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 2 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 3 2`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 1`] = `0`;
+
+exports[`TileModel can compute the rotation angle for a tile oriented to the right with a ratio of 4 2`] = `0`;
+
+exports[`TileModel can compute the side of the curve for a tile with a ratio of 0.5 1`] = `0`;
+
+exports[`TileModel can compute the side of the curve for a tile with a ratio of 1 1`] = `0`;
+
+exports[`TileModel can compute the side of the curve for a tile with a ratio of 2 1`] = `0`;
+
+exports[`TileModel can compute the side of the curve for a tile with a ratio of 3 1`] = `0`;
+
+exports[`TileModel can compute the side of the curve for a tile with a ratio of 4 1`] = `0`;


### PR DESCRIPTION
Add data models for representing the track tiles. They are applying similar computation as for the 3D printing project.

Use them with:

```javascript
import {
    CurvedTileEnlargedModel,
    CurvedTileModel,
    StraightTileModel
} from 'src/track/models';

const enlarged = new CurvedTileEnlargedModel(specs, direction, ratio);
const curved = new CurvedTileModel(specs, direction, ratio);
const straight = new StraightTileModel(specs, direction, ratio);
```